### PR TITLE
Add per server channel locking

### DIFF
--- a/src/main/kotlin/io/github/yuutoproject/yuutobot/Listener.kt
+++ b/src/main/kotlin/io/github/yuutoproject/yuutobot/Listener.kt
@@ -51,6 +51,14 @@ class Listener : ListenerAdapter() {
             return
         }
 
+        val botcmdsChannel = Yuuto.config["BOTCMDS_${event.guild.idLong}"]
+
+        // if the botcms channel is set for the server and the channel is the channel stored
+        // commands can be eecuted, if not this will return
+        if (botcmdsChannel != null && botcmdsChannel != event.channel.id) {
+            return
+        }
+
         val args = content.substring(prefix.length)
             .trim()
             .split("\\s+".toRegex())


### PR DESCRIPTION
This way Yuuto can be used outside of the camp buddy server

config value is `BOTCMDS_${guild_id}=channel_id`
If the value is not set for a guild all channels will be unlocked